### PR TITLE
Add integration test using Testcontainers

### DIFF
--- a/write-app/pom.xml
+++ b/write-app/pom.xml
@@ -1,50 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.9</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.salaboy.dapr</groupId>
-	<artifactId>write-app</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>write-app</name>
-	<description>Dapr Statecomponent Write</description>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.dapr</groupId>
-			<artifactId>dapr-sdk-springboot</artifactId>
-			<version>1.8.0</version>
-		</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.9</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.salaboy.dapr</groupId>
+    <artifactId>write-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>write-app</name>
+    <description>Dapr Statecomponent Write</description>
+    <properties>
+        <java.version>17</java.version>
+        <testcontainers.version>1.18.0</testcontainers.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dapr</groupId>
+            <artifactId>dapr-sdk-springboot</artifactId>
+            <version>1.8.0</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.3.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Exclude Groovy because of classpath issue -->
+                <exclusion>
+                    <groupId>org.apache.groovy</groupId>
+                    <artifactId>groovy-xml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    </dependencies>
+
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/write-app/src/main/java/com/salaboy/dapr/javaapp/JavaAppApplication.java
+++ b/write-app/src/main/java/com/salaboy/dapr/javaapp/JavaAppApplication.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.dapr.client.domain.State;
 
 
+import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -27,7 +28,7 @@ public class JavaAppApplication {
 	@Value("${STATE_STORE_NAME:statestore}")
 	private String STATE_STORE_NAME = "";
 
-	private DaprClient client = new DaprClientBuilder().build();
+	private DaprClient client;
 
 	public static void main(String[] args) {
 		SpringApplication.run(JavaAppApplication.class, args);
@@ -54,6 +55,11 @@ public class JavaAppApplication {
 	@DeleteMapping("/")
 	public void deleteAllValues() {
 		client.deleteState(STATE_STORE_NAME, "values").block();
+	}
+
+	@PostConstruct
+	void initDapr() {
+		client = new DaprClientBuilder().build();
 	}
 
 	public record MyValues(List<String> values) {}

--- a/write-app/src/test/java/com/salaboy/dapr/javaapp/JavaAppApplicationTests.java
+++ b/write-app/src/test/java/com/salaboy/dapr/javaapp/JavaAppApplicationTests.java
@@ -1,13 +1,69 @@
 package com.salaboy.dapr.javaapp;
 
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.MountableFile;
 
-@SpringBootTest
+import java.util.stream.Stream;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class JavaAppApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @LocalServerPort
+    private int localPort;
 
+    private static Network daprNetwork = Network.newNetwork();
+
+    private static final GenericContainer<?> daprSidecar = new GenericContainer<>("daprio/daprd:edge")
+            .withCommand("./daprd",
+                    "-app-id", "write-app",
+                    "-placement-host-address", "placement:50006",
+                    "--dapr-listen-addresses=0.0.0.0",
+                    "-components-path", "/components")
+            .withExposedPorts(50001)
+            .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("components"),
+                    "/components/")
+            .withNetwork(daprNetwork);
+
+    private static final GenericContainer<?> daprPlacement = new GenericContainer<>("daprio/dapr")
+            .withCommand("./placement", "-port", "50006")
+            .withExposedPorts(50006) // for wait
+            .withNetwork(daprNetwork)
+            .withNetworkAliases("placement");
+
+    private static final GenericContainer<?> redis = new GenericContainer<>("redis:alpine")
+            .withExposedPorts(6379) // for wait
+            .withNetwork(daprNetwork)
+            .withNetworkAliases("redis");
+
+    @DynamicPropertySource
+    static void daprProperties(DynamicPropertyRegistry registry) {
+        Stream.of(daprSidecar, daprPlacement, redis).parallel().forEach(GenericContainer::start);
+        System.setProperty("dapr.grpc.port", daprSidecar.getMappedPort(50001).toString());
+    }
+
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void canPostToEndpoint() {
+        RestAssured.given().port(localPort).param("value", "foo")
+                .when().post("/")
+                .then().statusCode(200);
+
+        RestAssured.given().port(localPort).param("value", "bar")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("values", Matchers.contains("foo", "bar"));
+    }
 }

--- a/write-app/src/test/resources/components/pubsub.yaml
+++ b/write-app/src/test/resources/components/pubsub.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: redis:6379
+  - name: redisPassword
+    value: ""

--- a/write-app/src/test/resources/components/statestore.yaml
+++ b/write-app/src/test/resources/components/statestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: keyPrefix
+    value: name
+  - name: redisHost
+    value: redis:6379
+  - name: redisPassword
+    value: ""


### PR DESCRIPTION
Add a first integration test `canPostToEndpoint` to the `write-app` using Testcontainers to spin up Dapr and other dependencies.

The base container setup can be also used to start the Spring Boot application in "dev mode" from the test sources and hence replace Docker Compose completely (will be done in a follow-up).