### PR TITLE
Reuse containers

### DIFF
--- a/write-app/src/main/resources/application.properties
+++ b/write-app/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.port=8081

--- a/write-app/src/test/java/com/salaboy/dapr/javaapp/CommonContainers.java
+++ b/write-app/src/test/java/com/salaboy/dapr/javaapp/CommonContainers.java
@@ -1,19 +1,54 @@
 package com.salaboy.dapr.javaapp;
 
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.MountableFile;
 
+import java.util.List;
+
 public interface CommonContainers {
 
-    Network daprNetwork = Network.newNetwork();
+    Network daprNetwork = getNetwork();
+
+    static Network getNetwork() {
+        Network defaultDaprNetwork = new Network() {
+            @Override
+            public String getId() {
+                return "dapr";
+            }
+
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public Statement apply(Statement base, Description description) {
+                return null;
+            }
+        };
+
+        List<com.github.dockerjava.api.model.Network> networks = DockerClientFactory.instance().client().listNetworksCmd().withNameFilter("dapr").exec();
+        if (networks.isEmpty()) {
+            Network.builder()
+                    .createNetworkCmdModifier(cmd -> cmd.withName("dapr"))
+                    .build().getId();
+            return defaultDaprNetwork;
+        } else {
+            return defaultDaprNetwork;
+        }
+    }
 
     GenericContainer<?> redis = new GenericContainer<>("redis:alpine")
             .withExposedPorts(6379) // for wait
             .withNetwork(daprNetwork)
-            .withNetworkAliases("redis");
+            .withNetworkAliases("redis")
+            .withReuse(true);
 
     GenericContainer<?> daprSidecar = new GenericContainer<>("daprio/daprd:edge")
             .withCommand("./daprd",
@@ -25,13 +60,15 @@ public interface CommonContainers {
             .withCopyFileToContainer(
                     MountableFile.forClasspathResource("components"),
                     "/components/")
-            .withNetwork(daprNetwork);
+            .withNetwork(daprNetwork)
+            .withReuse(true);
 
     GenericContainer<?> daprPlacement = new GenericContainer<>("daprio/dapr")
             .withCommand("./placement", "-port", "50006")
             .withExposedPorts(50006) // for wait
             .withNetwork(daprNetwork)
-            .withNetworkAliases("placement");
+            .withNetworkAliases("placement")
+            .withReuse(true);
 
     @DynamicPropertySource
     static void daprProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
* opt-in containers to reuse mode
* create network if doesn't exist. Otherwise, just join the network
* update server.port to 8081 to void port collision among apps.

Before running the apps make sure the `testcontainers.reuse.enable=true` exists in `~/.testcontainers.properties`. Once the apps are running there should be one redis, 2 dapr sidecars (one per app), one placement service.